### PR TITLE
Add cycle creation modal and update cycle navigation links

### DIFF
--- a/apps/misc/models.py
+++ b/apps/misc/models.py
@@ -47,12 +47,12 @@ class DateSpanQuerySet(QuerySet):
     def next(self, dt=None):
         """Return the next instance by start_date"""
         dt = timezone.now().date() if not dt else dt
-        return self.filter(start_date__gte=dt).order_by('start_date').first()
+        return self.filter(start_date__gt=dt).order_by('start_date').first()
 
     def prev(self, dt=None):
         """Return the next instance by start_date"""
         dt = timezone.now().date() if not dt else dt
-        return self.filter(start_date__lte=dt).order_by('-start_date').first()
+        return self.filter(start_date__lt=dt).order_by('-start_date').first()
 
     def inactive(self):
         """A proxy for expired"""

--- a/apps/projects/forms.py
+++ b/apps/projects/forms.py
@@ -142,7 +142,6 @@ class HandOverForm(forms.ModelForm):
         end_choices = shift_choices("Shifts", size=self.facility.shift_size)
 
         self.fields['start_time'].choices = start_choices.choices
-        self.fields['start_time'].initial = start_choices.NOW
         self.fields['end_time'].choices = end_choices.choices
 
         self.helper.layout = Layout(

--- a/apps/projects/templates/projects/session-detail.html
+++ b/apps/projects/templates/projects/session-detail.html
@@ -27,7 +27,7 @@
             <span class="tool-label">View Log</span>
         </a>
         {% if object.state == object.STATES.ready %}
-             {% if admin or owner %}
+             {% if admin  %}
                 <a href="#0" data-url="{% url 'delete-session' pk=object.pk %}" class="text-danger pull-right">
                     <i class="ti icon-2 bi-trash icon-fw"></i><br/>
                     <span class="tool-label">Delete</span>

--- a/apps/proposals/templates/proposals/cycle_detail.html
+++ b/apps/proposals/templates/proposals/cycle_detail.html
@@ -11,13 +11,17 @@
 {% block folio-subtitle %}Cycle &mdash; {{ object.pk }}{% endblock %}
 
 {% block folio-tools %}
-    <a class="pull-right"
-       {% if next_cycle %}href='{% url "review-cycle-detail" pk=next_cycle.pk %}'
-       {% else %}href='#0' disabled{% endif %}
-    >
-        <i class="bi-chevron-right icon-2 icon-fw"></i><br/>
-        <span class="tool-label">Next</span>
-    </a>
+    {% if next_cycle %}
+        <a class="pull-right" href='{% url "review-cycle-detail" pk=next_cycle.pk %}'>
+            <i class="bi-chevron-right icon-2 icon-fw"></i><br/>
+            <span class="tool-label">Next</span>
+        </a>
+    {% else %}
+        <a class="pull-right" href='#0!' data-url='{% url "add-review-cycles" pk=object.pk %}'>
+            <i class="bi-plus-lg icon-2 icon-fw"></i><br/>
+            <span class="tool-label">Add</span>
+        </a>
+    {% endif %}
     <a class="pull-right"
        {% if prev_cycle %}href='{% url "review-cycle-detail" pk=prev_cycle.pk %}'
        {% else %}href='#0' disabled{% endif %}

--- a/apps/proposals/templates/proposals/forms/create-cycle.html
+++ b/apps/proposals/templates/proposals/forms/create-cycle.html
@@ -1,0 +1,16 @@
+{% extends "forms/modal.html" %}
+{% load proposal_tags %}
+{% block form_title %}Add Cycle?{% endblock %}
+{% block form_body %}
+<h5>Are you sure you want to add a new Cycle?</h5>
+<div class="alert alert-warning">Cycles should normally be added automatically by background tasks.</div>
+<div class="row">
+	<div class="modal-footer">
+  			<form action="{% url 'add-review-cycles' object.pk %}" method="post">{% csrf_token %}
+   			<input type="hidden" name="post" value="yes" />
+			<button type="button" class="btn btn-default pull-left" data-dismiss="modal">Cancel</button>
+			<button type="submit" value="Submit" class="btn btn-info">Yes, I'm sure</button>
+		</form>
+	</div>
+</div>
+{% endblock %}

--- a/apps/proposals/urls.py
+++ b/apps/proposals/urls.py
@@ -28,8 +28,8 @@ urlpatterns = [
     path('facilities/<int:pk>/submissions/', views.BeamlineSubmissionList.as_view(), name='beamline-submissions'),
 
     path('cycles/', views.ReviewCycleList.as_view(), name="review-cycle-list"),
-    path('cycles/new', views.CreateReviewCycle.as_view(), name="create-review-cycle"),
     path('cycles/<int:pk>/', views.ReviewCycleDetail.as_view(), name="review-cycle-detail"),
+    path('cycles/<int:pk>/add/', views.AddReviewCycles.as_view(), name="add-review-cycles"),
     path('cycles/<int:pk>/edit/', views.EditReviewCycle.as_view(), name="edit-review-cycle"),
     path('review-tracks/<int:pk>/edit/', views.EditReviewTrack.as_view(), name="edit-review-track"),
     path('cycles/<int:pk>/assign/<int:track>/', views.AssignReviewers.as_view(), name="assign-reviewers"),


### PR DESCRIPTION
This pull request includes several changes across different files to improve functionality and fix issues. The most important changes include modifications to query filters, form initialization, template conditions, and URL routing for cycles.

Query filter adjustments:
* [`apps/misc/models.py`](diffhunk://#diff-e92370ab727f9e8d2c682abdb45bb0cfe77d16bd5a4df526bf85be1d11546a25L50-R55): Updated the `next` and `prev` methods to use strict inequality for date comparisons.

Form initialization changes:
* [`apps/projects/forms.py`](diffhunk://#diff-b7db7754d528ed76614c833404f065009e857e61b3ada38fa86b0e207c0024e3L145): Removed the initial value setting for the `start_time` field during form initialization.

Template condition updates:
* [`apps/projects/templates/projects/session-detail.html`](diffhunk://#diff-7f8bbd4644e0641a106c9ae49578e80489cf54be66c5ac9ec777e81baf27acc2L30-R30): Modified the condition to show the delete option only for admin users.
* [`apps/proposals/templates/proposals/cycle_detail.html`](diffhunk://#diff-232e516813bd6276ab0a0ac3903a800961be172ea24976adc77258b842fcf283L14-R24): Added a new "Add" option for cycles when there is no next cycle available.

URL routing and view updates for cycles:
* [`apps/proposals/urls.py`](diffhunk://#diff-23540ff7d3a85974ae7f28aa68d3d4a950eee0b94229062ec894b6bae2bc9a3dL31-R32): Added a new URL pattern for adding review cycles.
* [`apps/proposals/views.py`](diffhunk://#diff-5f63d29a24050fa95f7d7b736f0242220b43efd8340049865f0cec3c64555baaR1273-R1293): Introduced a new `AddReviewCycles` view to handle the addition of new cycles and removed the `CreateReviewCycle` view. [[1]](diffhunk://#diff-5f63d29a24050fa95f7d7b736f0242220b43efd8340049865f0cec3c64555baaR1273-R1293) [[2]](diffhunk://#diff-5f63d29a24050fa95f7d7b736f0242220b43efd8340049865f0cec3c64555baaL1016-L1023)