### PR TITLE
FEAT: Facility website icon added

### DIFF
--- a/apps/beamlines/templates/beamlines/detail.html
+++ b/apps/beamlines/templates/beamlines/detail.html
@@ -32,6 +32,15 @@
     {% endif %}
     {% if "employee" in user.roles %}
     {% endif %}
+
+    {% if object.url %}
+        <a href="{{ object.url }}" target="_blank" rel="noopener noreferrer">
+            <i class="bi-globe2 icon-md icon-fw"></i>
+            <br/>
+            <span class="tool-label">Website</span>
+        </a>
+    {% endif %}       
+
     {% if admin or user|is_staff:object %}
         <a href="{% url "facility-projects" slug=object.acronym %}">
             <i class="bi-briefcase icon-md icon-fw"></i>


### PR DESCRIPTION
### DESCRIPTION

I noticed that the website icon was missing on the Facility detail page, so I added it.

### SCREENSHOTS

<p align="center"><img width="1911" height="234" alt="image" src="https://github.com/user-attachments/assets/ff095c66-82f6-4907-a3d9-98c787cbdaa5" /> </p> <p align="center"><em>Website icon is now visible for the default user.</em></p>


<p align="center"> <img width="1911" height="234" alt="image" src="https://github.com/user-attachments/assets/e6c81ab5-bf42-481a-a879-4f3c167bfebc" /> </p> <p align="center"><em>Website icon is also visible for another user.</em></p>

### CHANGES

Added website icon to Facility detail page
